### PR TITLE
Make oidc-client lib http client agnostic

### DIFF
--- a/oidc-client/Dynamic.ml
+++ b/oidc-client/Dynamic.ml
@@ -1,62 +1,58 @@
 type 'store t = {
   kv : (module KeyValue.KV with type value = string and type store = 'store);
   store : 'store;
-  http_client : Piaf.Client.t;
   meta : Oidc.Client.meta;
   provider_uri : Uri.t;
 }
 
-let get_or_create_client { kv; store; http_client; provider_uri; meta } =
+let get_or_create_client ~get ~post { kv; store; provider_uri; meta } =
   let open Lwt_result.Infix in
-  Internal.discover ~kv ~store ~http_client ~provider_uri >>= fun discovery ->
-  ( Internal.register ~kv ~store ~http_client ~meta ~discovery >|= fun dynamic ->
+  Internal.discover ~kv ~store ~get ~provider_uri >>= fun discovery ->
+  ( Internal.register ~kv ~store ~post ~meta ~discovery >|= fun dynamic ->
     Oidc.Client.of_dynamic_and_meta ~dynamic ~meta )
   >>= fun client ->
-  Static.make ~kv ~store ~http_client
+  Lwt.return_ok @@ Static.make ~kv ~store
     ~redirect_uri:(List.hd meta.redirect_uris)
     ~provider_uri ~client
 
 let make (type store)
     ~(kv : (module KeyValue.KV with type value = string and type store = store))
     ~(store : store) ~provider_uri (meta : Oidc.Client.meta) =
-  Piaf.Client.create provider_uri
-  |> Lwt_result.map (fun http_client ->
-         { kv; store; http_client; meta; provider_uri })
+  { kv; store; meta; provider_uri }
 
-let get_jwks t = Lwt_result.bind (get_or_create_client t) Static.get_jwks
+let get_jwks ~get ~post t = Lwt_result.bind (get_or_create_client ~get ~post t) (Static.get_jwks ~get)
 
-let get_token ~code t =
-  Lwt_result.bind (get_or_create_client t) (Static.get_token ~code)
+let get_token ~code ~get ~post t =
+  Lwt_result.bind (get_or_create_client ~get ~post t) (Static.get_token ~code ~get ~post )
 
-let get_and_validate_id_token ?nonce ~code t =
+let get_and_validate_id_token ?nonce ~code ~get ~post t =
   Lwt_result.bind
-    (get_or_create_client t |> Utils.RPiaf.map_piaf_err)
-    (Static.get_and_validate_id_token ?nonce ~code)
+    (get_or_create_client ~get ~post t)
+    (Static.get_and_validate_id_token ?nonce ~code ~get ~post)
 
-let get_auth_result ~nonce ~params ~state t =
+let get_auth_result ~nonce ~get ~post ~params ~state t =
   Lwt_result.bind
-    (get_or_create_client t |> Utils.RPiaf.map_piaf_err)
-    (Static.get_auth_result ~nonce ~params ~state)
+    (get_or_create_client ~get ~post t)
+    (Static.get_auth_result ~nonce ~get ~post ~params ~state)
 
-let get_auth_parameters ?scope ?claims ~nonce ~state t =
-  get_or_create_client t |> Utils.RPiaf.map_piaf_err
+let get_auth_parameters ?scope ?claims ~nonce ~get ~post ~state t =
+  get_or_create_client~get ~post t
   |> Lwt_result.map (Static.get_auth_parameters ?scope ?claims ~nonce ~state)
 
-let get_auth_uri ?scope ?claims ~nonce ~state t =
+let get_auth_uri ?scope ?claims ~nonce ~get ~post ~state t =
   let open Lwt_result.Infix in
-  get_or_create_client t |> Utils.RPiaf.map_piaf_err
-  >>= Static.get_auth_uri ?scope ?claims ~nonce ~state
+  get_or_create_client ~get ~post t
+  >>= Static.get_auth_uri ?scope ?claims ~nonce ~get ~state
 
-let get_userinfo ~jwt ~token t =
+let get_userinfo ~get ~post ~jwt ~token t =
   Lwt_result.bind
-    (get_or_create_client t |> Utils.RPiaf.map_piaf_err)
-    (Static.get_userinfo ~jwt ~token)
+    (get_or_create_client ~get ~post t)
+    (Static.get_userinfo ~get ~jwt ~token)
 
-let register (t : 'store t) meta =
+let register ~get ~post (t : 'store t) meta =
   Lwt_result.bind
-    ( Internal.discover ~kv:t.kv ~store:t.store ~http_client:t.http_client
-        ~provider_uri:t.provider_uri
-    |> Utils.RPiaf.map_piaf_err )
+    ( Internal.discover ~kv:t.kv ~store:t.store ~get
+        ~provider_uri:t.provider_uri)
     (fun discovery ->
-      Internal.register ~kv:t.kv ~store:t.store ~http_client:t.http_client ~meta
+      Internal.register ~kv:t.kv ~store:t.store ~post ~meta
         ~discovery)

--- a/oidc-client/Dynamic.mli
+++ b/oidc-client/Dynamic.mli
@@ -7,7 +7,6 @@
 type 'store t = {
   kv : (module KeyValue.KV with type value = string and type store = 'store);
   store : 'store;
-  http_client : Piaf.Client.t;
   meta : Oidc.Client.meta;
   provider_uri : Uri.t;
 }
@@ -18,50 +17,95 @@ val make :
   store:'store ->
   provider_uri:Uri.t ->
   Oidc.Client.meta ->
-  ('store t, Piaf.Error.t) result Lwt.t
+  'store t
 
 val register :
+  get:(?headers:(string * string) list ->
+    string -> (string, [> `Msg of string ] as 'a) Lwt_result.t) ->
+  post:(?headers:(string * string) list ->
+    body:string -> string -> (string, 'a) Lwt_result.t) ->
   'store t ->
   Oidc.Client.meta ->
-  (Oidc.Client.dynamic_response, Piaf.Error.t) result Lwt.t
+  (Oidc.Client.dynamic_response, 'a) result Lwt.t
 (** Register a dynamic client, this will mostly be handled for you automatically but can be useful *)
 
-val get_jwks : 'store t -> (Jose.Jwks.t, Piaf.Error.t) result Lwt.t
+val get_jwks :
+  get:(?headers:(string * string) list ->
+    string -> (string, [> `Msg of string ] as 'a) Lwt_result.t) ->
+  post:(?headers:(string * string) list ->
+    body:string -> string -> (string, 'a) Lwt_result.t) ->
+  'store t ->
+  (Jose.Jwks.t, 'a) result Lwt.t
 
 val get_token :
-  code:string -> 'store t -> (Oidc.Token.t, Piaf.Error.t) result Lwt.t
+  code:string ->
+  get:(?headers:(string * string) list ->
+    string -> (string, [> `Msg of string ] as 'a) Lwt_result.t) ->
+  post:(?headers:(string * string) list ->
+    body:string -> string -> (string, 'a) Lwt_result.t) ->
+  'store t ->
+  (Oidc.Token.t, 'a) result Lwt.t
 
 val get_auth_parameters :
   ?scope:string list ->
   ?claims:Yojson.Safe.t ->
   nonce:string ->
+  get:(?headers:(string * string) list ->
+    string -> (string, [> `Msg of string ] as 'a) Lwt_result.t) ->
+  post:(?headers:(string * string) list ->
+    body:string -> string -> (string, 'a) Lwt_result.t) ->
   state:string ->
   'store t ->
-  (Oidc.Parameters.t, [> `Msg of string ]) result Lwt.t
+  (Oidc.Parameters.t, 'a) result Lwt.t
 
 val get_auth_uri :
   ?scope:string list ->
   ?claims:Yojson.Safe.t ->
   nonce:string ->
+  get:(?headers:(string * string) list ->
+    string -> (string, [> `Msg of string ] as 'a) Lwt_result.t) ->
+  post:(?headers:(string * string) list ->
+    body:string -> string -> (string, 'a) Lwt_result.t) ->
   state:string ->
   'store t ->
-  (string, Piaf.Error.t) result Lwt.t
+  (string, 'a) result Lwt.t
 
 val get_and_validate_id_token :
   ?nonce:string ->
   code:string ->
+  get:(?headers:(string * string) list ->
+    string ->
+    (string, Oidc.IDToken.validation_error) Lwt_result.t) ->
+  post:(?headers:(string * string) list ->
+    body:string ->
+    string ->
+    (string, Oidc.IDToken.validation_error) Lwt_result.t) ->
   'store t ->
   (Oidc.Token.t, Oidc.IDToken.validation_error) result Lwt.t
 
 val get_auth_result :
   nonce:string ->
+  get:(?headers:(string * string) list ->
+    string ->
+    (string, Oidc.IDToken.validation_error) Lwt_result.t) ->
+  post:(?headers:(string * string) list ->
+    body:string ->
+    string ->
+    (string, Oidc.IDToken.validation_error) Lwt_result.t) ->
   params:(string * string list) list ->
   state:string ->
   'a t ->
   (Oidc.Token.t, Oidc.IDToken.validation_error) result Lwt.t
 
 val get_userinfo :
+  get:(?headers:(string * string) list ->
+    string ->
+    (string,
+    [> `Missing_sub | `Msg of string | `Sub_missmatch ] as 'a)
+    Lwt_result.t) ->
+  post:(?headers:(string * string) list ->
+    body:string -> string -> (string, 'a) Lwt_result.t) ->
   jwt:Jose.Jwt.t ->
   token:string ->
   'a t ->
-  (string, [> `Missing_sub | `Msg of string | `Sub_missmatch ]) result Lwt.t
+  (string, 'a) result Lwt.t

--- a/oidc-client/Internal.ml
+++ b/oidc-client/Internal.ml
@@ -1,21 +1,20 @@
 open Utils
 
-let to_string_body (res : Piaf.Response.t) = Piaf.Body.to_string res.body
-
-let read_registration ~http_client ~client_id ~(discovery : Oidc.Discover.t) =
+let read_registration ~get ~client_id ~(discovery : Oidc.Discover.t) =
   match discovery.registration_endpoint with
   | Some endpoint ->
       let open Lwt_result.Infix in
       let registration_path = Uri.of_string endpoint |> Uri.path in
       let query = Uri.encoded_of_query [ ("client_id", [ client_id ]) ] in
       let uri = registration_path ^ query in
-      Piaf.Client.get http_client uri >>= to_string_body >>= fun s ->
+      get uri >>= fun s ->
       Oidc.Client.dynamic_of_string s |> Lwt.return
   | None -> Lwt_result.fail (`Msg "No_registration_endpoint")
 
 let register (type store)
     ~(kv : (module KeyValue.KV with type value = string and type store = store))
-    ~(store : store) ~http_client ~meta ~(discovery : Oidc.Discover.t) =
+    ~(store : store) ~(post: ?headers:(string * string) list ->
+      body:string -> string -> (string, 'a) Lwt_result.t) ~meta ~(discovery : Oidc.Discover.t) =
   let (module KV) = kv in
   let open Lwt_result.Infix in
   ( KV.get ~store "dynamic_string" >>= fun dynamic_string ->
@@ -31,10 +30,9 @@ let register (type store)
       | Ok dynamic, _ -> Lwt_result.return dynamic
       | Error _, Some endpoint ->
           let meta_string = Oidc.Client.meta_to_string meta in
-          let body = Piaf.Body.of_string meta_string in
+          let body = meta_string in
           let registration_path = Uri.of_string endpoint |> Uri.path in
-          ( Piaf.Client.post http_client ~body registration_path
-          >>= to_string_body
+          ( post ~body registration_path
           >>= fun dynamic_string ->
             let () =
               Log.debug (fun m -> m "dynamic string: %s" dynamic_string)
@@ -47,7 +45,8 @@ let register (type store)
 
 let discover (type store)
     ~(kv : (module KeyValue.KV with type value = string and type store = store))
-    ~(store : store) ~http_client ~provider_uri =
+    ~(store : store) ~(get: ?headers:(string * string) list ->
+      string -> (string, 'a) Lwt_result.t) ~provider_uri =
   let open Lwt_result.Infix in
   let (module KV) = kv in
   let save discovery =
@@ -61,15 +60,13 @@ let discover (type store)
           let discover_path =
             Uri.path provider_uri ^ "/.well-known/openid-configuration"
           in
-
           let () = print_endline (Uri.to_string provider_uri) in
-
-          Piaf.Client.get http_client discover_path >>= to_string_body >>= save)
+          get discover_path >>= save)
   |> Lwt_result.map Oidc.Discover.of_string
 
 let jwks (type store)
     ~(kv : (module KeyValue.KV with type value = string and type store = store))
-    ~(store : store) ~http_client ~provider_uri =
+    ~(store : store) ~get ~provider_uri =
   let open Lwt_result.Infix in
   let open Lwt_result.Syntax in
   let (module KV) = kv in
@@ -80,9 +77,9 @@ let jwks (type store)
       match result with
       | Ok jwks -> Lwt_result.return jwks
       | Error _ ->
-          let* discovery = discover ~kv ~store ~http_client ~provider_uri in
+          let* discovery = discover ~kv ~store ~get ~provider_uri in
           let jwks_path = Uri.of_string discovery.jwks_uri |> Uri.path in
-          Piaf.Client.get http_client jwks_path >>= to_string_body >>= save)
+          get jwks_path >>= save)
   |> Lwt_result.map Jose.Jwks.of_string
 
 (* TODO: Move to oidc lib *)

--- a/oidc-client/MicrosoftClient.mli
+++ b/oidc-client/MicrosoftClient.mli
@@ -10,6 +10,5 @@ val make :
   tenant_id:'a ->
   secret:string option ->
   redirect_uri:Uri.t ->
-  ?http_client:Piaf.Client.t ->
-  ('store Static.t, Piaf.Error.t) result Lwt.t
+  'store Static.t
 (** Creates a static Client configured for Microsft Azure AD *)

--- a/oidc-client/Utils.ml
+++ b/oidc-client/Utils.ml
@@ -18,12 +18,6 @@ module RResult = struct
   let ( >>= ) e f = flat_map f e
 end
 
-module RPiaf = struct
-  let map_piaf_err (x : ('a, Piaf.Error.t) Lwt_result.t) :
-      ('a, [> `Msg of string ]) Lwt_result.t =
-    Lwt_result.map_err (fun e -> `Msg (Piaf.Error.to_string e)) x
-end
-
 let src = Logs.Src.create "oidc_client" ~doc:"logs OIDC Client events"
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/oidc-client/dune
+++ b/oidc-client/dune
@@ -10,7 +10,7 @@ let () = Jbuild_plugin.V1.send @@ {|
 (library
  (name OidcClient)
  (public_name oidc-client)
- (libraries oidc piaf yojson uri)
+ (libraries oidc lwt yojson uri)
  |} ^ preprocess ^ {|)
 
 (documentation


### PR DESCRIPTION
Some exploration to see how an API that is not coupled with any client library would look like. It seems passing `get` and `post` simple function would work. 
@ulrikstrid curious what you think? Is this too verbose, and thus should we try an approach with functors and / or fcms? One thing I like about the `get` `post` is that is quite explicit what each function in the library will be doing in terms of requests.

The type sigs can be greatly improved, I just wanted to make it build first.

As a side note, I saw that the requests get a fresh url in all cases I saw. There is a module `Oneshot` in piaf for cases where a connection to target is not required to be kept opened. 

https://github.com/anmonteiro/piaf/blob/master/lib/piaf.mli#L615