### PR TITLE
{oauth,oidc}.Token.Response: add `make` and `to_json`

### DIFF
--- a/oauth/Token.mli
+++ b/oauth/Token.mli
@@ -16,7 +16,7 @@ module Response : sig
 
   val make :
     ?token_type:token_type ->
-    ?scope:string ->
+    ?scope:string list ->
     ?expires_in:int ->
     ?refresh_token:string ->
     access_token:string ->

--- a/oauth/Token.mli
+++ b/oauth/Token.mli
@@ -9,14 +9,23 @@ module Response : sig
     token_type : token_type;
     scope : string list;
     expires_in : int option;
-    ext_exipires_in : int option;
     access_token : string;
     refresh_token : string option;
   }
   (** A token response *)
 
+  val make :
+    ?token_type:token_type ->
+    ?scope:string ->
+    ?expires_in:int ->
+    ?refresh_token:string ->
+    access_token:string ->
+    unit ->
+    t
+
   val of_json : Yojson.Safe.t -> t
   val of_string : string -> t
+  val to_json : t -> Yojson.Safe.t
 end
 
 module Request : sig

--- a/oauth/TokenResponse.ml
+++ b/oauth/TokenResponse.ml
@@ -8,8 +8,8 @@ type t = {
   refresh_token : string option;
 }
 
-let make ?(token_type = Bearer) ?scope ?expires_in ?refresh_token ~access_token
-    () =
+let make ?(token_type = Bearer) ?(scope = []) ?expires_in ?refresh_token
+    ~access_token () =
   { token_type; scope; expires_in; access_token; refresh_token }
 
 let of_json json =
@@ -59,7 +59,8 @@ let to_json { scope; expires_in; access_token; refresh_token; _ } =
   let json_str = Option.map (fun x -> `String x) in
   `Assoc
     [
-      ("scope", or_null (json_str scope));
+      ( "scope",
+        match scope with [] -> `Null | _ -> `String (String.concat " " scope) );
       ("token_type", `String "Bearer");
       ("expires_in", or_null (Option.map (fun x -> `Int x) expires_in));
       ("access_token", `String access_token);

--- a/oidc/Client.mli
+++ b/oidc/Client.mli
@@ -28,7 +28,7 @@ val make :
 
 type meta = {
   redirect_uris : Uri.t list;
-  response_types : string list option;  (** TODO: use special respone_type *)
+  response_types : string list option;  (** TODO: use special response_type *)
   grant_types : string list option;  (** TODO: use special grant_type *)
   application_type : string option;  (** TODO: use special application_type *)
   contacts : string list option;  (** email addresses *)
@@ -45,7 +45,7 @@ type meta = {
   id_token_signed_response_alg : Jose.Jwa.alg option;
 }
 (**
-Metadata used in registration of dunamic clients
+Metadata used in registration of dynamic clients
  *)
 
 val make_meta :

--- a/oidc/SimpleClient.ml
+++ b/oidc/SimpleClient.ml
@@ -97,6 +97,6 @@ let valid_token_of_string ?clock_tolerance ~jwks ~discovery t body =
   |> Token.Response.validate ?clock_tolerance ~jwks ~discovery ~client:t.client
 
 let valid_userinfo_of_string ~(token_response : Token.Response.t) userinfo =
-  match Jose.Jwt.of_string token_response.id_token with
+  match Jose.Jwt.of_string (Option.get token_response.id_token) with
   | Ok jwt -> Userinfo.validate ~jwt userinfo
   | Error e -> Error e

--- a/oidc/Token.mli
+++ b/oidc/Token.mli
@@ -17,7 +17,7 @@ module Response : sig
 
   val make :
     ?token_type:token_type ->
-    ?scope:string ->
+    ?scope:string list ->
     ?expires_in:int ->
     ?access_token:string ->
     ?refresh_token:string ->

--- a/oidc/Token.mli
+++ b/oidc/Token.mli
@@ -9,15 +9,25 @@ module Response : sig
     token_type : token_type;
     scope : string list;
     expires_in : int option;
-    ext_exipires_in : int option;
     access_token : string option;
     refresh_token : string option;
     id_token : string;
   }
   (** A token response *)
 
+  val make :
+    ?token_type:token_type ->
+    ?scope:string ->
+    ?expires_in:int ->
+    ?access_token:string ->
+    ?refresh_token:string ->
+    id_token:string ->
+    unit ->
+    t
+
   val of_json : Yojson.Safe.t -> t
   val of_string : string -> t
+  val to_json : t -> Yojson.Safe.t
 
   val validate :
     ?clock_tolerance:int ->

--- a/oidc/Token.mli
+++ b/oidc/Token.mli
@@ -11,7 +11,7 @@ module Response : sig
     expires_in : int option;
     access_token : string option;
     refresh_token : string option;
-    id_token : string;
+    id_token : string option;
   }
   (** A token response *)
 
@@ -21,7 +21,7 @@ module Response : sig
     ?expires_in:int ->
     ?access_token:string ->
     ?refresh_token:string ->
-    id_token:string ->
+    ?id_token:string ->
     unit ->
     t
 

--- a/oidc/TokenResponse.ml
+++ b/oidc/TokenResponse.ml
@@ -9,8 +9,8 @@ type t = {
   id_token : string;
 }
 
-let make ?(token_type = Bearer) ?scope ?expires_in ?access_token ?refresh_token
-    ~id_token () =
+let make ?(token_type = Bearer) ?(scope = []) ?expires_in ?access_token
+    ?refresh_token ~id_token () =
   { token_type; scope; expires_in; access_token; refresh_token; id_token }
 
 let of_json json =
@@ -86,7 +86,8 @@ let to_json { scope; expires_in; access_token; refresh_token; id_token; _ } =
   let json_str = Option.map (fun x -> `String x) in
   `Assoc
     [
-      ("scope", or_null (json_str scope));
+      ( "scope",
+        match scope with [] -> `Null | _ -> `String (String.concat " " scope) );
       ("token_type", `String "Bearer");
       ("expires_in", or_null (Option.map (fun x -> `Int x) expires_in));
       ("access_token", or_null (json_str access_token));


### PR DESCRIPTION
It's useful to create a `Token.Response.t` if you're implementing a provider.