### PR TITLE
Scope: model as list of strings

### DIFF
--- a/executable/PiafOidc.ml
+++ b/executable/PiafOidc.ml
@@ -12,4 +12,4 @@ let request_descr_to_request Oidc.SimpleClient.{ headers; uri; body; meth } =
   let body = Option.map Piaf.Body.of_string body in
   Piaf.Client.Oneshot.request ~headers ?body ~meth uri
   >>= to_string_body
-  |> Lwt_result.map_err map_piaf_error
+  |> Lwt_result.map_error map_piaf_error

--- a/oauth/Token.mli
+++ b/oauth/Token.mli
@@ -7,7 +7,7 @@ module Response : sig
 
   type t = {
     token_type : token_type;
-    scope : string option;
+    scope : string list;
     expires_in : int option;
     ext_exipires_in : int option;
     access_token : string;

--- a/oauth/TokenResponse.ml
+++ b/oauth/TokenResponse.ml
@@ -2,7 +2,7 @@ type token_type = Bearer
 
 type t = {
   token_type : token_type;
-  scope : string option;
+  scope : string list;
   expires_in : int option;
   ext_exipires_in : int option;
   access_token : string;
@@ -11,10 +11,23 @@ type t = {
 
 let of_json json =
   let module Json = Yojson.Safe.Util in
+  let scope =
+    match Json.member "scope" json with
+    | `Null -> []
+    | `String scope -> [scope]
+    | `List json ->
+      (* Some OIDC providers (Twitch for example) return an array of strings
+         for scope. *)
+      List.map Json.to_string json
+    | json ->
+      raise
+        (Json.Type_error
+           ("scope: expected a string or an array of strings", json))
+  in
   {
     token_type = Bearer;
     (* Only Bearer is supported by OIDC, TODO = return a error if it is not Bearer *)
-    scope = json |> Json.member "scope" |> Json.to_string_option;
+    scope;
     expires_in = json |> Json.member "expires_in" |> Json.to_int_option;
     ext_exipires_in =
       json |> Json.member "ext_exipires_in" |> Json.to_int_option;
@@ -23,10 +36,15 @@ let of_json json =
   }
 
 let of_query query =
+  let scope =
+    let qp = Uri.get_query_param query "scope" in
+    Option.value ~default:[]
+      (Option.map (fun qp -> String.split_on_char ' ' qp) qp)
+  in
   {
     token_type = Bearer;
     (* Only Bearer is supported by OIDC, TODO = return a error if it is not Bearer *)
-    scope = Uri.get_query_param query "scope";
+    scope;
     expires_in =
       Uri.get_query_param query "expires_in" |> Option.map int_of_string;
     ext_exipires_in =

--- a/oidc-client/Utils.ml
+++ b/oidc-client/Utils.ml
@@ -15,7 +15,7 @@ end
 module RPiaf = struct
   let map_piaf_err (x : ('a, Piaf.Error.t) Lwt_result.t) :
       ('a, [> `Msg of string]) Lwt_result.t =
-    Lwt_result.map_err (fun e -> `Msg (Piaf.Error.to_string e)) x
+    Lwt_result.map_error (fun e -> `Msg (Piaf.Error.to_string e)) x
 end
 
 let src = Logs.Src.create "oidc_client" ~doc:"logs OIDC Client events"

--- a/oidc/Token.mli
+++ b/oidc/Token.mli
@@ -7,7 +7,7 @@ module Response : sig
 
   type t = {
     token_type : token_type;
-    scope : string option;
+    scope : string list;
     expires_in : int option;
     ext_exipires_in : int option;
     access_token : string option;


### PR DESCRIPTION
The fact that scope is a space-separated string of scopes is an implementation detail. We can expose a better interface in the OCaml type and save users pain.