### PR TITLE
Safer and unified scope handling

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -18,7 +18,8 @@ jobs:
 
       - uses: cachix/cachix-action@v10
         with:
-          name: anmonteiro
+          name: stridtech
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: "Run nix flake check"
         run: nix flake check
@@ -27,11 +28,8 @@ jobs:
         run: nix develop -c dune runtest --instrument-with bisect_ppx --force --no-buffer
 
       - name: Send coverage report
-        run: nix develop -c bisect-ppx-report send-to Coveralls
+        run: nix develop -c bisect-ppx-report send-to Codecov
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_NUMBER: ${{ github.event.number }}
 
       - name: "Generate documentation"
         run: nix develop -c dune build @doc --force --no-buffer

--- a/.github/workflows/opam-build.yml
+++ b/.github/workflows/opam-build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - run: opam install ./oidc.opam --deps-only --with-test
 
-      - run: opam exec -- dune build
+      - run: opam exec -- dune build ./oidc
 
       - run: opam exec -- dune runtest
 

--- a/executable/DreamOauthClient.ml
+++ b/executable/DreamOauthClient.ml
@@ -14,8 +14,9 @@ let () =
        [
          ( Dream.get "/auth" @@ fun request ->
            let params =
-             Oidc.Parameters.make ~scope:["repo"; "read:user"] client
-               ~redirect_uri
+             Oidc.Parameters.make
+               ~scope:[`S "repo"; `S "read:user"]
+               client ~redirect_uri
            in
            let uri = Uri.of_string "https://github.com/login/oauth/authorize" in
            let redirect_uri =
@@ -31,7 +32,8 @@ let () =
              in
              let request_body =
                Oidc.Token.Request.make ~client ~grant_type:"code"
-                 ~scope:["repo"] ~redirect_uri ~code
+                 ~scope:[`S "repo"]
+                 ~redirect_uri ~code
                |> Oidc.Token.Request.to_body_string
              in
              let open Lwt.Syntax in

--- a/executable/DreamOidcMiddleware.ml
+++ b/executable/DreamOidcMiddleware.ml
@@ -74,7 +74,7 @@ let callback_handler ~redirect_to ~discovery ~jwks ~client request =
 
 let middleware ?(auth_endpoint = "/auth")
     ?(callback_endpoint = "/auth/callback") ?(redirect_to = "/") ?remember:_
-    ?(scope = ["openid"; "email"; "profile"]) ~discovery ~jwks client =
+    ?(scope = [`OpenID; `Email; `Profile]) ~discovery ~jwks client =
   let auth_handler = auth_handler ~discovery ~client ~scope in
   let callback_handler =
     callback_handler ~redirect_to ~discovery ~jwks ~client

--- a/oidc-client/Dynamic.mli
+++ b/oidc-client/Dynamic.mli
@@ -33,7 +33,7 @@ val get_token :
   code:string -> 'store t -> (Oidc.Token.Response.t, Piaf.Error.t) result Lwt.t
 
 val get_auth_parameters :
-  ?scope:string list ->
+  ?scope:Oidc.Scopes.t list ->
   ?claims:Yojson.Safe.t ->
   nonce:string ->
   state:string ->
@@ -41,7 +41,7 @@ val get_auth_parameters :
   (Oidc.Parameters.t, [> `Msg of string]) result Lwt.t
 
 val get_auth_uri :
-  ?scope:string list ->
+  ?scope:Oidc.Scopes.t list ->
   ?claims:Yojson.Safe.t ->
   nonce:string ->
   state:string ->

--- a/oidc-client/Static.ml
+++ b/oidc-client/Static.ml
@@ -37,7 +37,8 @@ let get_token ~code t =
   (* TODO: Move this into Oidc.Token *)
   let body =
     Oidc.Token.Request.make ~client:t.client ~grant_type:"authorization_code"
-      ~scope:["openid"] ~redirect_uri:t.redirect_uri ~code
+      ~scope:[`OpenID]
+      ~redirect_uri:t.redirect_uri ~code
     |> Oidc.Token.Request.to_body_string
     |> Piaf.Body.of_string
   in

--- a/oidc-client/Static.mli
+++ b/oidc-client/Static.mli
@@ -38,7 +38,7 @@ val get_jwks : 'store t -> (Jose.Jwks.t, Piaf.Error.t) result Lwt.t
     you validate the token. This is typically done via session storage. *)
 
 val get_auth_parameters :
-  ?scope:string list ->
+  ?scope:Oidc.Scopes.t list ->
   ?claims:Yojson.Safe.t ->
   ?nonce:string ->
   state:string ->
@@ -46,7 +46,7 @@ val get_auth_parameters :
   Oidc.Parameters.t
 
 val get_auth_uri :
-  ?scope:string list ->
+  ?scope:Oidc.Scopes.t list ->
   ?claims:Yojson.Safe.t ->
   ?nonce:string ->
   state:string ->

--- a/oidc/Oidc.ml
+++ b/oidc/Oidc.ml
@@ -2,6 +2,7 @@ module SimpleClient = SimpleClient
 module Client = Client
 module Discover = Discover
 module Parameters = Parameters
+module Scopes = Scopes
 module Token = Token
 module IDToken = IDToken
 module Jwks = Jwks

--- a/oidc/Oidc.mli
+++ b/oidc/Oidc.mli
@@ -7,6 +7,7 @@ module SimpleClient = SimpleClient
 module Client = Client
 module Discover = Discover
 module Parameters = Parameters
+module Scopes = Scopes
 module Token = Token
 module IDToken = IDToken
 module Jwks = Jwks

--- a/oidc/Parameters.mli
+++ b/oidc/Parameters.mli
@@ -16,7 +16,7 @@ type t = {
   response_type : string list;
   client : Client.t;
   redirect_uri : Uri.t;
-  scope : string list;
+  scope : Scopes.t list;
   state : string option;
   nonce : string option;
   claims : Yojson.Safe.t option;
@@ -38,7 +38,7 @@ type error =
 
 val make :
   ?response_type:string list ->
-  ?scope:string list ->
+  ?scope:Scopes.t list ->
   ?state:string ->
   ?claims:Yojson.Safe.t ->
   ?max_age:int ->

--- a/oidc/Scopes.ml
+++ b/oidc/Scopes.ml
@@ -1,44 +1,31 @@
-type scope =
-  | OpenID
-  | Profile
-  | Email
-  | Address
-  | Phone
-  | NonStandard of string
+type t =
+  [ `OpenID
+  | `Profile
+  | `Email
+  | `Address
+  | `Phone
+  | `Offline_access
+  | `S of string ]
 
 let of_string = function
-  | "openid" -> OpenID
-  | "profile" -> Profile
-  | "email" -> Email
-  | "address" -> Address
-  | "phone" -> Phone
-  | non_standard -> NonStandard non_standard
+  | "openid" -> `OpenID
+  | "profile" -> `Profile
+  | "email" -> `Email
+  | "address" -> `Address
+  | "phone" -> `Phone
+  | "offline_access" -> `Offline_access
+  | non_standard -> `S non_standard
 
-let to_claims scope =
-  match scope with
-  | OpenID -> []
-  | Profile ->
-    [
-      Claims.NonEssential "name";
-      Claims.NonEssential "family_name";
-      Claims.NonEssential "given_name";
-      Claims.NonEssential "middle_name";
-      Claims.NonEssential "nickname";
-      Claims.NonEssential "preferred_username";
-      Claims.NonEssential "profile";
-      Claims.NonEssential "picture";
-      Claims.NonEssential "website";
-      Claims.NonEssential "gender";
-      Claims.NonEssential "birthdate";
-      Claims.NonEssential "zoneinfo";
-      Claims.NonEssential "locale";
-      Claims.NonEssential "updated_at";
-    ]
-  | Email -> [Claims.NonEssential "email"; Claims.NonEssential "email_verified"]
-  | Address -> [Claims.NonEssential "address"]
-  | Phone ->
-    [
-      Claims.NonEssential "phone_number";
-      Claims.NonEssential "phone_number_verified";
-    ]
-  | NonStandard s -> [Claims.Essential s]
+let to_string = function
+  | `OpenID -> "openid"
+  | `Profile -> "profile"
+  | `Email -> "email"
+  | `Address -> "address"
+  | `Phone -> "phone"
+  | `Offline_access -> "offline_access"
+  | `S s -> s
+
+let of_scope_parameter parameter =
+  String.split_on_char ' ' parameter |> List.map of_string
+
+let to_scope_parameter scopes = List.map to_string scopes |> String.concat " "

--- a/oidc/Scopes.mli
+++ b/oidc/Scopes.mli
@@ -1,4 +1,22 @@
-type scope
+(** https://openid.net/specs/openid-connect-basic-1_0.html#Scopes *)
 
-val of_string : string -> scope
-val to_claims : scope -> Claims.claim list
+type t =
+  [ `OpenID
+    (** REQUIRED. Informs the Authorization Server that the Client is making an OpenID Connect request. If the openid scope value is not present, the behavior is entirely unspecified.  *)
+  | `Profile
+    (** OPTIONAL. This scope value requests access to the End-User's default profile Claims, which are: name, family_name, given_name, middle_name, nickname, preferred_username, profile, picture, website, gender, birthdate, zoneinfo, locale, and updated_at. *)
+  | `Email
+    (** OPTIONAL. This scope value requests access to the email and email_verified Claims. *)
+  | `Address
+    (** OPTIONAL. This scope value requests access to the address Claim. *)
+  | `Phone
+    (** OPTIONAL. This scope value requests access to the phone_number and phone_number_verified Claims. *)
+  | `Offline_access
+    (** OPTIONAL. This scope value requests that an OAuth 2.0 Refresh Token be issued that can be used to obtain an Access Token that grants access to the End-User's UserInfo Endpoint even when the End-User is not present (not logged in). *)
+  | `S of string ]
+(** REQUIRED and optional are just for OpenID connect, OAuth2 doesn't have any defiend scopes *)
+
+val of_string : string -> t
+val to_string : t -> string
+val of_scope_parameter : string -> t list
+val to_scope_parameter : t list -> string

--- a/oidc/SimpleClient.ml
+++ b/oidc/SimpleClient.ml
@@ -45,7 +45,8 @@ type request_descr = {
 let make_token_request ~code ~discovery t =
   let body =
     Token.Request.make ~client:t.client ~grant_type:"authorization_code"
-      ~scope:["openid"] ~redirect_uri:t.redirect_uri ~code
+      ~scope:[`OpenID]
+      ~redirect_uri:t.redirect_uri ~code
     |> Token.Request.to_body_string
   in
   let headers =

--- a/oidc/SimpleClient.mli
+++ b/oidc/SimpleClient.mli
@@ -38,7 +38,7 @@ val discovery_uri : t -> Uri.t
 (** Get the discovery_uri as specified in the {{:https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig} OIDC spec} *)
 
 val make_auth_uri :
-  ?scope:string list ->
+  ?scope:Scopes.t list ->
   ?claims:Yojson.Safe.t ->
   ?nonce:string ->
   state:string ->
@@ -134,7 +134,7 @@ let jwks =
 When the user is supposed to login you create the URI and redirect the user to the provider.
 
 {[
-  let uri = Oidc.SimpleClient.make_auth_uri ~scope:["openid"; "email"; "profile"] ~state:"state" ~discovery client in
+  let uri = Oidc.SimpleClient.make_auth_uri ~scope:[`OpenID; `Email; `Profile] ~state:"state" ~discovery client in
   HttpServer.redirect uri
 ]}
 

--- a/oidc/Token.mli
+++ b/oidc/Token.mli
@@ -7,7 +7,7 @@ module Response : sig
 
   type t = {
     token_type : token_type;
-    scope : string list;
+    scope : Scopes.t list;
     expires_in : int option;
     access_token : string option;
     refresh_token : string option;
@@ -17,7 +17,7 @@ module Response : sig
 
   val make :
     ?token_type:token_type ->
-    ?scope:string list ->
+    ?scope:Scopes.t list ->
     ?expires_in:int ->
     ?access_token:string ->
     ?refresh_token:string ->
@@ -44,7 +44,7 @@ module Request : sig
 
   type t = {
     grant_type : string;
-    scope : string list;
+    scope : Scopes.t list;
     code : string;
     client_id : string;
     client_secret : string option;
@@ -55,7 +55,7 @@ module Request : sig
   val make :
     client:Client.t ->
     grant_type:string ->
-    scope:string list ->
+    scope:Scopes.t list ->
     redirect_uri:Uri.t ->
     code:string ->
     t

--- a/oidc/TokenRequest.ml
+++ b/oidc/TokenRequest.ml
@@ -2,7 +2,7 @@ open Utils
 
 type t = {
   grant_type : string;
-  scope : string list;
+  scope : Scopes.t list;
   code : string;
   client_id : string;
   client_secret : string option;
@@ -22,7 +22,7 @@ let make ~(client : Client.t) ~grant_type ~scope ~redirect_uri ~code =
 let to_body_string t =
   [
     ("grant_type", [t.grant_type]);
-    ("scope", t.scope);
+    ("scope", [Scopes.to_scope_parameter t.scope]);
     ("code", [t.code]);
     ("client_id", [t.client_id]);
     ("client_secret", [t.client_secret |> ROpt.get_or ~default:"secret"]);
@@ -43,7 +43,7 @@ let to_body_string t =
 let of_body_string body =
   let query = Uri.query_of_encoded body |> Uri.with_query Uri.empty in
   let gt = Uri.get_query_param query "grant_type" in
-  let s = Uri.get_query_param' query "scope" in
+  let s = Uri.get_query_param query "scope" in
   let c = Uri.get_query_param query "code" in
   let ci = Uri.get_query_param query "client_id" in
   let client_secret = Uri.get_query_param query "client_secret" in
@@ -53,7 +53,7 @@ let of_body_string body =
     Ok
       {
         grant_type;
-        scope;
+        scope = Scopes.of_scope_parameter scope;
         code;
         client_id;
         client_secret;

--- a/test/OidcParameters.ml
+++ b/test/OidcParameters.ml
@@ -36,7 +36,7 @@ let to_query () =
         response_type = ["code"];
         client;
         redirect_uri = Uri.of_string "https://client.example.org/cb";
-        scope = ["openid"; "profile"];
+        scope = [`OpenID; `Profile];
         state = Some "af0ifjsldkj";
         nonce = Some "n-0S6_WzA2Mj";
         claims = None;

--- a/test/Scopes.ml
+++ b/test/Scopes.ml
@@ -1,0 +1,38 @@
+(**
+ * Copyright 2022 Ulrik Strid. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ *)
+
+open Helpers
+
+let create_scopes () =
+  check_string "Create scope parameter" "openid"
+    ([`OpenID] |> Oidc.Scopes.to_scope_parameter)
+
+let parse_parameter () =
+  Alcotest.(check @@ list string)
+    "Parse scope parameter"
+    [
+      "openid";
+      "email";
+      "profile";
+      "address";
+      "phone";
+      "offline_access";
+      "user:repos";
+    ]
+    (Oidc.Scopes.of_scope_parameter
+       "openid email profile address phone offline_access user:repos"
+    |> List.map Oidc.Scopes.to_string)
+
+let tests =
+  List.map make_test_case
+    [
+      ("Create scopes parameter", create_scopes);
+      ("Parse scope parameter", parse_parameter);
+    ]
+
+let suite, _ =
+  Junit_alcotest.run_and_report ~package:"oidc" "Scopes"
+    [("OIDC - scopes", tests)]

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,6 +1,7 @@
 let () =
   let path = Sys.getenv_opt "REPORT_PATH" in
   let report =
-    Junit.make [OidcParameters.suite; Jwt.suite; Jwks.suite; Token.suite]
+    Junit.make
+      [OidcParameters.suite; Jwt.suite; Jwks.suite; Token.suite; Scopes.suite]
   in
   match path with Some path -> Junit.to_file report path | None -> ()


### PR DESCRIPTION
This allows us to treat scopes the same everywhere so that nothing slips through the cracks. We can also do debug logging when `openid` is missing while serializing since it's required in the OIDC case.