### PR TITLE
Parameters.t: don't require a `Client.t`, `of_yojson` doesn't require all clients

### DIFF
--- a/oidc/Parameters.ml
+++ b/oidc/Parameters.ml
@@ -155,7 +155,7 @@ let of_yojson  json : (t, [> error]) result =
       }
   with _ -> Error `Invalid_parameters
 
-let parse_query ~(allowed_redirect_uris : string list) uri : (t, [> error]) result =
+let parse_query uri : (t, [> error]) result =
   let getQueryParam param =
     Uri.get_query_param uri param |> function
     | Some x -> Ok x
@@ -189,8 +189,7 @@ let parse_query ~(allowed_redirect_uris : string list) uri : (t, [> error]) resu
     in
 
     match (response_type, redirect_uri, scope) with
-    | Ok response_type, Ok redirect_uri, Ok scope
-      when List.mem redirect_uri allowed_redirect_uris ->
+    | Ok response_type, Ok redirect_uri, Ok scope ->
       Ok
         {
           response_type;
@@ -208,7 +207,6 @@ let parse_query ~(allowed_redirect_uris : string list) uri : (t, [> error]) resu
             RResult.flat_map string_to_prompt (getQueryParam "prompt")
             |> ROpt.of_result;
         }
-    | Ok _, Ok redirect_uri, Ok _ -> Error (`Invalid_redirect_uri redirect_uri)
     | Error e, _, _ -> Error e
     | _, Error e, _ -> Error e
     | _, _, Error e -> Error e)

--- a/oidc/Parameters.mli
+++ b/oidc/Parameters.mli
@@ -58,5 +58,5 @@ val of_yojson : Yojson.Safe.t -> (t, [> error]) result
 
 (** {2 Parsing in the provider} *)
 
-val parse_query : allowed_redirect_uris:string list -> Uri.t -> (t, [> error]) result
+val parse_query : Uri.t -> (t, [> error]) result
 

--- a/oidc/Parameters.mli
+++ b/oidc/Parameters.mli
@@ -14,7 +14,7 @@ type prompt =
 
 type t = {
   response_type : string list;
-  client : Client.t;
+  client_id : string;
   redirect_uri : Uri.t;
   scope : Scopes.t list;
   state : string option;
@@ -45,17 +45,18 @@ val make :
   ?display:display ->
   ?prompt:prompt ->
   ?nonce:string ->
-  Client.t ->
   redirect_uri:Uri.t ->
+  client_id:string ->
+  unit ->
   t
 
 val to_query : t -> (string * string list) list
 (** Used when starting a authentication *)
 
 val to_yojson : t -> Yojson.Safe.t
-val of_yojson : clients:Client.t list -> Yojson.Safe.t -> (t, [> error]) result
+val of_yojson : Yojson.Safe.t -> (t, [> error]) result
 
 (** {2 Parsing in the provider} *)
 
-val parse_query : clients:Client.t list -> Uri.t -> (t, [> error]) result
- 
+val parse_query : allowed_redirect_uris:string list -> Uri.t -> (t, [> error]) result
+

--- a/oidc/SimpleClient.ml
+++ b/oidc/SimpleClient.ml
@@ -84,8 +84,10 @@ let make_userinfo_request ~(token : Token.Response.t) ~(discovery : Discover.t)
   | None, _ -> Error `Missing_userinfo_endpoint
 
 let get_auth_parameters ?scope ?claims ?nonce ~state t =
-  Parameters.make ?scope ?claims t.client ?nonce ~state
+  Parameters.make ?scope ?claims ?nonce ~state
     ~redirect_uri:t.redirect_uri
+    ~client_id:t.client.id
+    ()
 
 let make_auth_uri ?scope ?claims ?nonce ~state ~discovery t =
   let query =

--- a/test/OidcParameters.ml
+++ b/test/OidcParameters.ml
@@ -19,11 +19,12 @@ let valid_query =
 
 let parse_query () =
   match
-    Oidc.Parameters.parse_query ~clients
+    Oidc.Parameters.parse_query
+    ~allowed_redirect_uris:(List.map Uri.to_string client.redirect_uris)
       (Uri.of_string (base_url ^ valid_query))
   with
   | Ok valid_parameters ->
-    check_string "client_id" "s6BhdRkqt3" valid_parameters.client.id;
+    check_string "client_id" "s6BhdRkqt3" valid_parameters.client_id;
     check_string "redirect_uri" "https://client.example.org/cb"
       (Uri.to_string valid_parameters.redirect_uri);
     check_option_string "nonce" "n-0S6_WzA2Mj" valid_parameters.nonce
@@ -34,7 +35,7 @@ let to_query () =
     Oidc.Parameters.
       {
         response_type = ["code"];
-        client;
+        client_id= client.id;
         redirect_uri = Uri.of_string "https://client.example.org/cb";
         scope = [`OpenID; `Profile];
         state = Some "af0ifjsldkj";

--- a/test/OidcParameters.ml
+++ b/test/OidcParameters.ml
@@ -19,9 +19,7 @@ let valid_query =
 
 let parse_query () =
   match
-    Oidc.Parameters.parse_query
-    ~allowed_redirect_uris:(List.map Uri.to_string client.redirect_uris)
-      (Uri.of_string (base_url ^ valid_query))
+    Oidc.Parameters.parse_query (Uri.of_string (base_url ^ valid_query))
   with
   | Ok valid_parameters ->
     check_string "client_id" "s6BhdRkqt3" valid_parameters.client_id;


### PR DESCRIPTION
- `Parameters.t` stores just the `client_id`, not the entire client
- `of_yojson` doesn't require implementations to have all possible clients in memory